### PR TITLE
Проверка доступа пользователя к endpoint

### DIFF
--- a/app/api/v1/endpoints/task.py
+++ b/app/api/v1/endpoints/task.py
@@ -76,12 +76,12 @@ async def get_tasks(
 async def create_task(
         plan_id: PK_TYPE,
         task_create: TaskCreate,
-        user: User = Depends(PermissionChecker([Permissions.EMPLOYEE])),
+        user: User = Depends(PermissionChecker([Permissions.SUPERVISOR])),
         session: AsyncSession = Depends(get_async_session),
 ):
     """Создание задачи. Добавление нового нового комментарияк задаче."""
     await validators.check_plan_and_user_access(plan_id, user.id, session)
-    await validators.check_role(user)
+    # await validators.check_role(user)
     await validators.check_plan_tasks_expired_date(
         session, plan_id, task_create.expires_at
     )

--- a/app/api/v1/endpoints/task.py
+++ b/app/api/v1/endpoints/task.py
@@ -13,7 +13,8 @@ from schemas.comment import CommentType
 from schemas.plan import PlanStatus
 from schemas.task import (TaskCreate, TaskRead, TaskReadWithComments,
                           TaskStatus, TaskUpdate)
-from services.user import User, get_user
+from services.user import User, get_user, PermissionChecker
+from core.config import Permissions
 
 logger = logger_factory(__name__)
 
@@ -75,7 +76,7 @@ async def get_tasks(
 async def create_task(
         plan_id: PK_TYPE,
         task_create: TaskCreate,
-        user: User = Depends(get_user),
+        user: User = Depends(PermissionChecker([Permissions.EMPLOYEE])),
         session: AsyncSession = Depends(get_async_session),
 ):
     """Создание задачи. Добавление нового нового комментарияк задаче."""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,3 +1,4 @@
+import enum
 import os
 from pathlib import Path
 
@@ -61,3 +62,8 @@ class Settings:
 
 
 settings = Settings()
+
+
+class Permissions(str, enum.Enum):
+    SUPERVISOR = 'supervisor'
+    EMPLOYEE = 'employee'


### PR DESCRIPTION
Можно вместо get_user добавить класс проверки пользователя и в каждом эндпоинте добавить уровень доступа

```
async def create_task(
        plan_id: PK_TYPE,
        task_create: TaskCreate,
        user: User = Depends(PermissionChecker([Permissions.EMPLOYEE])),
        session: AsyncSession = Depends(get_async_session),
):
```

Это просто идея, и один пример в создании таска
Кто что думает?
Если что, добавлю это во всем endpoints