### PR TITLE
Добавил создание уведомлений о новых комментариях

### DIFF
--- a/app/api/v1/endpoints/comment.py
+++ b/app/api/v1/endpoints/comment.py
@@ -18,7 +18,7 @@ logger = logger_factory(__name__)
 
 router = APIRouter()
 
-NEW_COMMENT = '{author} оставил новый комментарий по задаче {task}'
+NEW_COMMENT = '{author} {task}'
 
 
 @router.get(

--- a/app/api/v1/validators.py
+++ b/app/api/v1/validators.py
@@ -70,7 +70,6 @@ async def check_role(
 
 
 async def check_plan_tasks_expired_date(
-        session: AsyncSession,
         plan: Plan,
         date_in_task: date
 ) -> None:

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -15,6 +15,15 @@ class NotificationType(str, enum.Enum):
     COMMON = 'common'
 
 
+class NotificationHeader(str, enum.Enum):
+    TASK_DONE = "Задача выполнена"
+    TASK_NEW = "Новая задача"
+    TASK_REVIEW = "Задача на проверке"
+    TASK_FAILED = "Задача не выполнена"
+    TASK_IN_PROGRESS = "Задача в работе"
+    COMMENT_NEW = "Новый комментарий"
+
+
 class NotificationBase(SQLModel):
     type: NotificationType
     header: str

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -21,7 +21,7 @@ class NotificationHeader(str, enum.Enum):
     TASK_REVIEW = "Задача на проверке"
     TASK_FAILED = "Задача не выполнена"
     TASK_IN_PROGRESS = "Задача в работе"
-    COMMENT_NEW = "Новый комментарий"
+    COMMENT_NEW = "Добавлен комментарий"
 
 
 class NotificationBase(SQLModel):


### PR DESCRIPTION
Логика следующая:

При создании нового комментария, всем участникам, связанным с задачей, кроме самого автора комментария (в нашем случае это всегда один человек: начальник или подчинённый), содаётся уведомление о новом комментарии. При этом, если аналогичное непрочитанное уведомление уже существует, нового не создаётся. Такой механизм избавит "читателя" от получения 10 уведомлений, если кто-то написал 10 комментариев, а "читатель" еще не успел их прочитать.

Чтобы этот механизм работал в полной мере, приходится при запросе списка комметариев делать непрочитанное уведомление о новом комметарии (при его наличии) прочитанным. Мне эта логика показалась естественной - если пользователя прочитал комментарии, логично скрывать неактуальное уведомление о новых комметариях.